### PR TITLE
Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+
+go:
+ - 1.8.x 
+ - 1.9.x
+ - master
+
+install:
+ - go get -t ./...
+
+script:
+ - go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,5 @@ go:
  - 1.9.x
  - master
 
-install:
- - go get -t ./...
-
 script:
  - go test -v ./...


### PR DESCRIPTION
Close #5 

The integration check code against latest Go 1.8.x, 1.9.x and master branch (security patches only, current and upcoming release).

You will still need to "enable" repository at https://travis-ci.org