### PR TITLE
Improve dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
-FROM golang:latest
+FROM golang:alpine
 WORKDIR /app
 ENV SOURCE_DIR=/go/src/github.com/piumaio/piuma
 ADD . ${SOURCE_DIR}
 
-RUN cd ${SOURCE_DIR}; go get -u; CGO_ENABLED=0 GOOS=linux go build -o app; cp app /app
+RUN apk add --update --no-cache git
+
+RUN cd ${SOURCE_DIR} && \
+  go get -u && \
+  CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o app && \
+  cp app /app
 
 FROM alpine:3.10.2
-RUN apk update
 
-# Install OptiPNG
-RUN apk add optipng
-
-## Install JPEGOptim
-RUN apk add jpegoptim
+# Install OptiPNG and JPEGOptim
+RUN apk add --update --no-cache optipng jpegoptim
 
 WORKDIR /root/
 COPY --from=0 /app .


### PR DESCRIPTION
Improvements:
- build the application inside an `alpine`-based container so that we link against the same libc
- run multiple commands with `&&` instead of `;`. This stops the build if one of them returns a non zero exit code (=fails)
- strip debug information from the binary with linker flags (`-s -w`)
- don't cache installed packages (with the apk `--no-cache` flag)

Image sizes before/after:
```sh
$ docker images
REPOSITORY          TAG                 IMAGE ID            SIZE
piuma-new           latest              8a50904a89dc        13.3MB
piuma-old           latest              e445ee225778        17.1MB
```